### PR TITLE
Show and hide header and continue arrow upon scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
+    "react-intersection-observer": "^8.25.2",
     "react-markdown": "^4.1.0",
     "styled-components": "^4.3.2",
     "styled-normalize": "^8.0.6"

--- a/src/components/Continue.jsx
+++ b/src/components/Continue.jsx
@@ -1,15 +1,16 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'gatsby';
 import styled from 'styled-components';
 
-const ContinueLink = props => (
+const ContinueLink = ({ visible, ...props }) => (
   <Link to="/#work" {...props}>
     <svg
       height="20"
       width="20"
       viewBox="0 0 20 20"
       role="img"
-      ariaLabelledby="title"
+      aria-labelledby="title"
     >
       <title id="title">Continue</title>
       <polyline
@@ -24,6 +25,10 @@ const ContinueLink = props => (
   </Link>
 );
 
+ContinueLink.propTypes = {
+  visible: PropTypes.bool.isRequired,
+};
+
 const Continue = styled(ContinueLink)`
   width: 20px;
   height: 20px;
@@ -34,7 +39,7 @@ const Continue = styled(ContinueLink)`
   left: 50%;
   transform: translateX(-50%);
   transition: opacity .25s;
-  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  opacity: ${({ visible }) => (visible ? '1' : '0')};
 `;
 
 export default Continue;

--- a/src/components/Continue.jsx
+++ b/src/components/Continue.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+
+const ContinueLink = props => (
+  <Link to="/#work" {...props}>
+    <svg
+      height="20"
+      width="20"
+      viewBox="0 0 20 20"
+      role="img"
+      ariaLabelledby="title"
+    >
+      <title id="title">Continue</title>
+      <polyline
+        points="0,0 10,10 20,0"
+        style={{
+          fill: 'none',
+          stroke: 'black',
+          strokeWidth: 1,
+        }}
+      />
+    </svg>
+  </Link>
+);
+
+const Continue = styled(ContinueLink)`
+  width: 20px;
+  height: 20px;
+  z-index: 1;
+  position: fixed;
+  display: block;
+  bottom: 3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: opacity .25s;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+`;
+
+export default Continue;

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -10,6 +10,7 @@ const LogoH1 = styled.h1`
   margin: 4vw 4vw;
   z-index: 1;
   position: relative;
+  letter-spacing: 0.15rem;
 
   a {
     text-decoration: none;

--- a/src/components/PositionTracker.jsx
+++ b/src/components/PositionTracker.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const PositionTracker = styled.div`
+  width: 0;
+  height: 0;
+  background: transparent;
+`;
+
+export default PositionTracker;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -12,7 +12,7 @@ const HeaderEl = styled.header`
   position: fixed;
   z-index: 1;
   transition: opacity .25s;
-  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  opacity: ${({ visible }) => (visible ? '1' : '0')};
 `;
 
 const Div = styled.div`

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -2,12 +2,17 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useInView } from 'react-intersection-observer';
 import Logo from './Logo';
 import MenuButton from './MenuButton';
+import PositionTracker from './PositionTracker';
+import Continue from './Continue';
 
 const HeaderEl = styled.header`
   position: fixed;
   z-index: 1;
+  transition: opacity .25s;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
 `;
 
 const Div = styled.div`
@@ -41,40 +46,41 @@ const NavEl = styled.nav`
 
 const Header = ({ siteTitle }) => {
   const [showMenu, setShowMenu] = useState(false);
+  const [ref, inView] = useInView();
   const handleEvent = () => setShowMenu(!showMenu);
 
   return (
-    <HeaderEl>
-      <Logo>
-        {siteTitle}
-      </Logo>
-      <NavEl>
-        <MenuButton
-          onClick={handleEvent}
-          close={showMenu}
-        />
-        <Div
-          onClick={handleEvent}
-          onKeyPress={handleEvent}
-          role="button"
-          showMenu={showMenu}
-        >
-          <a href="/#home">Home</a>
-          <a href="/#work">Work</a>
-          <a href="/#about">About</a>
-          <a href="/#contact">Contact</a>
-        </Div>
-      </NavEl>
-    </HeaderEl>
+    <>
+      <PositionTracker ref={ref} />
+      <HeaderEl visible={!inView}>
+        <Logo>
+          {siteTitle}
+        </Logo>
+        <NavEl>
+          <MenuButton
+            onClick={handleEvent}
+            close={showMenu}
+          />
+          <Div
+            onClick={handleEvent}
+            onKeyPress={handleEvent}
+            role="button"
+            showMenu={showMenu}
+          >
+            <a href="/#home">Home</a>
+            <a href="/#work">Work</a>
+            <a href="/#about">About</a>
+            <a href="/#contact">Contact</a>
+          </Div>
+        </NavEl>
+      </HeaderEl>
+      <Continue visible={inView} />
+    </>
   );
 };
 
 Header.propTypes = {
-  siteTitle: PropTypes.string,
-};
-
-Header.defaultProps = {
-  siteTitle: '',
+  siteTitle: PropTypes.string.isRequired,
 };
 
 export default Header;

--- a/src/content-modules/HomeModule.jsx
+++ b/src/content-modules/HomeModule.jsx
@@ -1,20 +1,9 @@
 import React from 'react';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
-import { graphql, useStaticQuery, Link } from 'gatsby';
+import { graphql, useStaticQuery } from 'gatsby';
 import styled from 'styled-components';
 import SEO from '../components/seo';
 import ModuleLayout from '../components/ModuleLayout';
-
-const ContinueLink = props => (
-  <Link to="/#work" {...props}>Continue</Link>
-);
-
-const Continue = styled(ContinueLink)`
-  position: absolute;
-  bottom: 3rem;
-  left: 50%;
-  transform: translateX(-50%);
-`;
 
 const HomeModuleLayout = styled(ModuleLayout)`
   display: flex;
@@ -70,7 +59,6 @@ const HomeModule = () => {
       <WrapperDiv>
         {documentToReactComponents(json)}
       </WrapperDiv>
-      <Continue />
     </HomeModuleLayout>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9532,6 +9532,13 @@ react-hot-loader@^4.8.4:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
+react-intersection-observer@^8.25.2:
+  version "8.25.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.25.2.tgz#be165f4827dc8f1927ab68ecb837efe913d94909"
+  integrity sha512-KymKTOQK0TxQFW/Km80oS8VVOZAX8nt74fsYEGw6pqBLSJlqBXEhdFpyPcBa08GiGnup8lrFRkSY4JioP+pqww==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
@@ -11143,6 +11150,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-invariant@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
 tinycolor2@^1.1.2:
   version "1.4.1"


### PR DESCRIPTION
The intial landing page view does not need to display the menu or monogram. The header should be hidden until scrolling down.

Conversely, the down arrow prompt should be hidden once the user starts scrolling.

This commit adds these inverse showing and hiding features.