### PR TITLE
Prevent menu from hiding when scrolling to page top

### DIFF
--- a/src/components/Continue.jsx
+++ b/src/components/Continue.jsx
@@ -32,7 +32,7 @@ ContinueLink.propTypes = {
 const Continue = styled(ContinueLink)`
   width: 20px;
   height: 20px;
-  z-index: 1;
+  z-index: 0;
   position: fixed;
   display: block;
   bottom: 3rem;

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -50,7 +50,11 @@ const Header = ({ siteTitle }) => {
   const [ref, inView] = useInView();
   const handleEvent = () => setShowMenu(!showMenu);
   const showHeader = !inView || showMenu;
-  document.body.style.overflow = showMenu ? 'hidden' : 'visible';
+
+  // guard against missing document during SSR
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = showMenu ? 'hidden' : 'visible';
+  }
 
   return (
     <>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -52,7 +52,7 @@ const Header = ({ siteTitle }) => {
   return (
     <>
       <PositionTracker ref={ref} />
-      <HeaderEl visible={!inView}>
+      <HeaderEl visible={!inView || showMenu}>
         <Logo>
           {siteTitle}
         </Logo>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/interactive-supports-focus */
+/* global document */
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -48,11 +49,13 @@ const Header = ({ siteTitle }) => {
   const [showMenu, setShowMenu] = useState(false);
   const [ref, inView] = useInView();
   const handleEvent = () => setShowMenu(!showMenu);
+  const showHeader = !inView || showMenu;
+  document.body.style.overflow = showMenu ? 'hidden' : 'visible';
 
   return (
     <>
       <PositionTracker ref={ref} />
-      <HeaderEl visible={!inView || showMenu}>
+      <HeaderEl visible={showHeader}>
         <Logo>
           {siteTitle}
         </Logo>


### PR DESCRIPTION
This ensures that the menu is always visible when active.