### PR TITLE
Menu fade in / out transition

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -17,7 +17,10 @@ const HeaderEl = styled.header`
 `;
 
 const Div = styled.div`
-  display: ${({ showMenu }) => (showMenu ? 'flex' : 'none')};
+  display: flex;
+  transition: opacity .25s, visibility .25s;
+  opacity: ${({ showMenu }) => (showMenu ? '1' : '0')};
+  visibility: ${({ showMenu }) => (showMenu ? 'visible' : 'hidden')};
   justify-content: center;
   align-items: center;
   flex-direction: column;


### PR DESCRIPTION
Fade in the main mav menu using a CSS transition.

This technique works, although the first transition causes the fonts to 'flash' when run in dev mode. Apparently this is a styled components global includes issue. The current workaround is to import your fonts outside of styled components. Given this only affects development, this can be overlooked for now.